### PR TITLE
Lock AngelDocs to specific version.

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,9 +20,9 @@ jobs:
       - uses: actions/checkout@v2
 
       # Run our action to document our code
-      - uses: KaiPrince/AngelDocs@latest
+      - uses: KaiPrince/AngelDocs@v0.1
         with:
-          files: crypto/**/*.*
+          files: crypto
           folder: dist
           base-url: Crypto # REPLACE WITH YOUR REPO NAME
           project-name: Crypto # REPLACE WITH YOUR PROJECT NAME

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -23,9 +23,9 @@ jobs:
       - uses: KaiPrince/AngelDocs@v0.1
         with:
           files: crypto
-          folder: dist
-          base-url: Crypto # REPLACE WITH YOUR REPO NAME
-          project-name: Crypto # REPLACE WITH YOUR PROJECT NAME
+          folder: dist # Must match folder name in action below
+          base-url: Crypto
+          project-name: Crypto
 
       # Publish to Pages
       - name: Deploy 🚀


### PR DESCRIPTION
## Overview

Lock the GitHub action for [AngelDocs](https://github.com/KaiPrince/AngelDocs) to a specific version.

### Reason for change

This will prevent errors that occur when usage / syntax changes are made to the project before they are updated here. (i.e. what happened last time).

### Changes summarized

- Lock to `v0.1`.

### Suggested future tasks

- Replace trigger branch `dev` with `main`, once this fix is confirmed.

## Checklist

- [x] No new warnings are introduced
- [x] Comments and documentation are up to date
- [x] TODOs resolved or added to issue tracker
- [x] No commented-out code
- [x] This isn't a 'quick-and-dirty' job